### PR TITLE
Add Ubuntu iptables instructions

### DIFF
--- a/faststart/deploy-virtual-server.md
+++ b/faststart/deploy-virtual-server.md
@@ -223,6 +223,18 @@ For RHEL:
 # sudo iptables-save | grep <port #>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+For Ubuntu:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# sudo iptables -I INPUT -p tcp --dport <port#> -j ACCEPT 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to make your changes permanently, issue this command:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# sudo bash -c "iptables-save > /etc/iptables/rules.v4" 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 1.  You must log in with the user ‘linux1’ with your SSH private key. No
     modification (use of password authentication, for example) is allowed.
 


### PR DESCRIPTION
Now that Ubuntu is available for the L1CC, add instructions for opening a port
with iptables and making the change permanent.